### PR TITLE
fix: drop orphaned M3 font block glued onto main.tsx by the stack merge

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -3,18 +3,3 @@ import { mount } from "@pocketjs/framework/solid";
 import Shell from "./app.tsx";
 
 mount(() => <Shell />);
-
-// Era fonts: swap the build's Inter atlases for the baked Tahoma ones
-// (tools/bake-fonts.ts, custom shell:font.* pak keys). Runs right after
-// mount() — the host is installed by then, and the first frame() has not
-// painted yet, so the first visible frame is already Tahoma.
-// load_font_atlas registers by the slot in the blob header: last load wins.
-if (hasPack()) {
-  for (const key of ["shell:font.0", "shell:font.7"]) {
-    try {
-      getOps().loadFontAtlas?.(get(key));
-    } catch (e) {
-      console.log(`era font ${key} not loaded: ${e}`);
-    }
-  }
-}


### PR DESCRIPTION
Merge artifact from the stack landing: the `-X ours` merge of main into `feat/m4-themes` auto-appended M3's runtime font-loading tail onto M4's rewritten `main.tsx` (non-conflicting hunk, no imports) — every golden failed on main with `hasPack is not defined`. M4 loads era fonts from the skin effect in `app.tsx`; `main.tsx` returns to the plain mount.

Verified: `bunx tsc --noEmit` clean, all 10 goldens byte-exact on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)