### PR TITLE
fix(ipod): pin removable user app deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/pocketjs"]
 	path = vendor/pocketjs
 	url = https://github.com/pocket-stack/pocketjs.git
-	branch = shell-submodule
+	branch = main

--- a/ipod/README.md
+++ b/ipod/README.md
@@ -16,7 +16,7 @@ of this repository (`../LICENSE`).
  iPod touch 4 (480x320 landscape)      USB (usbmuxd)      Omarchy machine
  ┌────────────────────────────────┐    PKNT/TCP      ┌──────────────────────────┐
  │ ipod/ (Solid)                  │◀───────────────▶│ host/serve.ts (Node)     │
- │ hosts/iphone2g/svcwire.c       │  or WiFi+beacon  │  .socket.sock  requests  │
+ │ hosts/ios-legacy/svcwire.c    │  or WiFi+beacon  │  .socket.sock  requests  │
  └────────────────────────────────┘                  │  .socket2.sock events    │
                                                      │  omarchy-* / wtype       │
                                                      │  pocket-pointer (wl)     │
@@ -303,7 +303,7 @@ uinput, no root, no extra daemon.
 
 Spec ops 30–32 (`svcOpen`/`svcPoll`/`svcSend`) over the SVC WIRE (PKNT) TCP
 transport, exactly the mailbox the PSP, Vita and 3DS companions speak.
-`hosts/iphone2g/svcwire.c` is the legacy Apple hosts' transport — a port of
+`hosts/ios-legacy/svcwire.c` is the legacy Apple hosts' transport — a port of
 the 3DS one (non-blocking BSD sockets pumped once per guest frame, no
 threads) — compiled in only when `POCKET_SVC_WIRE` is defined.
 
@@ -430,3 +430,26 @@ touches in the view's rotated space.
   advances the world by one touchless frame and would end the hold.)
 - `bun scripts/omarchy.ts client 127.0.0.1:8623 --for 4` — a scripted
   device against a live daemon.
+
+## Installation on iOS 6
+
+**`bun run ipod deploy` installs a removable User application** through the
+vendored PocketJS MobileInstallation tool. The device needs AppSync Unified
+and its Cydia Substrate dependencies for these local self-signed builds.
+`bun run ipod doctor` checks the device and toolchain prerequisites.
+
+```sh
+POCKETJS_IPODTOUCH4_UDID=<device-udid> bun run ipod deploy
+POCKETJS_IPODTOUCH4_UDID=<device-udid> bun run ipod launch
+POCKETJS_IPODTOUCH4_UDID=<device-udid> bun run ipod uninstall
+```
+
+An update preserves the User container’s data. Long-press the SpringBoard
+icon and use the native delete badge, or run `uninstall`, to remove the app
+and its container. The deployment tool migrates older System installations
+with a recovery backup and verifies the installed bundle before removing it.
+The icon artwork fills the square canvas; iOS supplies the rounded mask and
+shadow without a second baked border.
+
+The runtime submodule tracks PocketJS `main`. The committed submodule hash
+selects the exact toolchain used by a checkout.

--- a/ipod/host/serve.ts
+++ b/ipod/host/serve.ts
@@ -14,7 +14,7 @@
 //
 // USB: when the device is plugged into this machine, usbmuxd (the usbmuxd
 // package) lists it and iproxy can forward a host port to the device's
-// listener (hosts/iphone2g/svcwire.c, port 8624). The daemon polls for
+// listener (hosts/ios-legacy/svcwire.c, port 8624). The daemon polls for
 // devices, forwards a port per device and connects to it — the wire is the
 // same, only who dials is reversed, and a device on the cable is trusted:
 // physical possession is the pairing.
@@ -742,7 +742,7 @@ if (options.beacon) {
 // usb (usbmuxd): forward a host port to each plugged device's listener and dial it
 // ---------------------------------------------------------------------------
 
-/** hosts/iphone2g/svcwire.c POCKET_SVC_LISTEN_PORT. */
+/** hosts/ios-legacy/svcwire.c POCKET_SVC_LISTEN_PORT. */
 const USB_DEVICE_PORT = 8624;
 const USB_LOCAL_PORT_BASE = 8630;
 

--- a/ipod/host/wire.ts
+++ b/ipod/host/wire.ts
@@ -2,7 +2,7 @@
 // ipod/host/wire.ts — the host side of the SVC WIRE (PKNT)
 // protocol: framing, the device hello, the discovery beacon. Byte layouts
 // come from contracts/spec/spec.ts "SVC WIRE protocol" and must stay
-// bit-identical to engine/core/src/wire.rs and hosts/iphone2g/svcwire.c.
+// bit-identical to engine/core/src/wire.rs and hosts/ios-legacy/svcwire.c.
 //
 // The constants are repeated here rather than imported so the daemon can be
 // copied to the Omarchy machine as one small directory with no repository

--- a/scripts/ipod.ts
+++ b/scripts/ipod.ts
@@ -4,6 +4,7 @@
 //
 //   bun run ipod build          bundle the guest and link the app bundle
 //   bun run ipod deploy         build, then install over usbmuxd
+//   bun run ipod uninstall      remove the app and its data container
 //   bun run ipod launch         open it on the device
 //   bun run ipod status         the device's acceptance record
 //   bun run ipod doctor         what the toolchain is missing


### PR DESCRIPTION
Pocket Shell’s iPod deploy command now uses PocketJS main at `6a0a1b6`, which installs removable User applications through iOS 6 MobileInstallation, preserves data on update, and provides native uninstall. The pin includes the selected D artwork with an opaque User icon face so SpringBoard’s rounded mask does not expose the old inset rim.

Move submodule branch tracking to main now that the external Shell runtime has landed. Document the AppSync prerequisite, selected-device commands, migration and native deletion, and update transport references to `hosts/ios-legacy/svcwire.c`.

Validation: `bun run check` passed typechecking and all 98 unit/simulation tests across both apps. On the connected iPod4,1 / iOS 6.1.6, build `d2c092b77c9fa0d80a832541062f78d3` installed as a User app with byte-exact readback. A fresh launch passed GLES1/displaylink at 960×640, and its capture was visually verified. The app reaches desktop discovery; end-to-end Omarchy control is not claimed. Runtime changes landed in pocket-stack/pocketjs#364, #365, and #368 before this product pin was updated.
