### PR TITLE
chore(3ds): use merged runtime and current HBL icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ animations in `media/`, the byte-exact frames in `test/goldens/3ds/`, and the
 headless replay in `test/sim.test.ts`. Add a behaviour worth showing to a tape
 rather than filming by hand, and it becomes documentation and a test at once.
 
-**A guest crash on a shared SD card looks like the wrong app booting.** The
-runtime's recovery chain falls back to the last-good package, which on a card
-that also holds another Pocket product is that other product. Read
-`/pocketjs/runtime/status.txt` before believing a packaging problem.
+**Recovery state is isolated per app.** Pocket Shell uses
+`/pocketjs/runtime/apps/552d35dd1578b13f/`. Read its `status.txt` and
+`last-error.txt` when investigating guest boot or rollback. Legacy shared
+`/pocketjs/runtime/state` does not belong to this app slot.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ the console's own GPU. The iPod's are rendered in the headless simulator,
 which runs the same guest bundle the device runs.
 [How the pictures were made](docs/CAPTURE.md).*
 
+The runtime submodule pins merged PocketJS main at `10aee589`. **3DS builds
+embed independently drawn 24×24 and 48×48 HBL icons**, using the same assets
+as Pocket Doc. Pocket Shell keeps its recovery state under
+`/pocketjs/runtime/apps/552d35dd1578b13f/`; hold **L+R+START** to return to HBL.
+See [runtime upgrade validation](docs/RUNTIME-UPGRADE.md).
+
 ## The iPod touch: the desktop in one hand
 
 The companion is a **480×320 landscape panel** that mirrors the focused

--- a/docs/RUNTIME-UPGRADE.md
+++ b/docs/RUNTIME-UPGRADE.md
@@ -1,0 +1,23 @@
+# Runtime upgrade validation
+
+Validated on 2026-09-06 against PocketJS main
+`10aee589d95aca34802ea4f8c79023e929434a92`.
+
+The runtime includes the current HBL icon assets, per-app recovery storage,
+L+R+START exit, and the merged 3DS companion transport. Its shared socket
+service also supports Pocket Doc's offload worker.
+
+- `bun run check`: TypeScript plus 98 unit/simulator tests passed for both the 3DS and iPod apps (8,169 assertions).
+- `bun run 3ds`: full ARM build passed using the pinned runtime and toolchain.
+- Both embedded SMDH icons (24×24 and 48×48) match the already hardware-accepted Pocket Doc package byte for byte. Decoded RGB565 pixels were visually checked.
+- The rebuilt `/3DS/pocketshell-main.3dsx` was uploaded over FTP and read back byte for byte. Its isolated runtime slot had no staged or active replacement packages, so the next launch uses the newly embedded guest.
+
+| Artifact | Value |
+| --- | --- |
+| 3DSX bytes | 2865476 |
+| 3DSX SHA-256 | `6bcf2c4af14fe3f14f51ed71d6fc42eddc875c438150d45e9d797776f36d27f4` |
+| Combined SMDH icon SHA-256 | `d2f5674914634ba7b99ffe222fef9e7905692e59c22e125f4a18c946df479f07` |
+
+**Fresh physical interaction with this Pocket Shell build is pending.** FTP
+readback confirms the installed bytes; it does not confirm a new HBL launch
+or input handling. The earlier Pocket Doc hardware acceptance is separate.


### PR DESCRIPTION
Pin PocketJS to merged main `10aee589`, bringing the current 24×24/48×48 HBL icons and per-app runtime recovery into the 3DS build. The icon bytes match the hardware-accepted Pocket Doc package. Update the recovery documentation and record the final build/deployment hashes.

Validation: `bun run check` passed TypeScript and all 98 unit/simulator tests across the 3DS and iPod apps; the full ARM `bun run 3ds` build passed. The resulting launcher was uploaded to the console and read back byte for byte. Fresh HBL launch and interaction for this rebuilt Shell remain pending; deployment evidence is in `docs/RUNTIME-UPGRADE.md`.
